### PR TITLE
WL-2956 Do the re-writing of content when parsing.

### DIFF
--- a/library/src/webapp/js/headscripts.js
+++ b/library/src/webapp/js/headscripts.js
@@ -635,21 +635,6 @@ function browserSafeDocHeight() {
 	return Math.max(winHeight,docHeight); 
 }
 
-// In the absence of jQuery, add an event listener
-function addEvent(element, event, fn) {
-    if (element.addEventListener) {
-        element.addEventListener(event, fn, false);
-    } else if (element.attachEvent) {
-        // IE 8
-        element.attachEvent('on' + event, fn);
-    }
-}
-
-// Fixes links / references to insecure content once the window loads
-function fixMixedContentOnLoad() {
-    addEvent(window, 'load', fixMixedContentReferences);
-}
-
 // Fix for mixed content blocked in Firefox and IE, includes youtube refs and link hrefs
 function fixMixedContentReferences() {
     rewriteVideoEmbeds();
@@ -726,7 +711,6 @@ function rewriteVideoEmbeds() {
             embed.parentNode.replaceChild(clone, embed);
         }
     }
-
     var iframes = document.getElementsByTagName('iframe');
     for(var i = 0; i < iframes.length; ++i) {
         var iframe = iframes[i]


### PR DESCRIPTION
This removes unused JavaScript. If you attempt to fix YouTube URLs in IE9 by re-writing the DOM using a DOMContentLoaded or onload event it doesn’t fire and you just get a warning about insecure content. Switching back to rendering the page as a IE8 Document works, but we don’t want to force all modern versions of IE to be crippled. The only other fix that worked was to actually re-write the content when the page is loading. This still results in a warning message, but it does at least allow the page to work.
