### PR TITLE
WL-1631 Round times consistently.

### DIFF
--- a/library/src/webapp/js/lang-datepicker/lang-datepicker.js
+++ b/library/src/webapp/js/lang-datepicker/lang-datepicker.js
@@ -2081,6 +2081,7 @@ isRTL:false
 		var options = this.options,
 			cfg = {};
 
+		// This is the instance of the dateTimePicker
 		var localDTPicker;
 
 		cfg.showOn = (options.icon === 0) ? "focus" : "both";
@@ -2134,32 +2135,9 @@ isRTL:false
 				parseDate = d;
 			};
 
-			var roundDate = roundMinutes(parseDate)
-			window.console && console.log('parsed and rounded date: ' + roundDate);
-
-			return roundDate;
+			return parseDate;
 		}
 
-
-		/**
-		 * Utility method to round a date object to the closest stepMinute (15 by default) minutes
-		 * 
-		 * @param  {object} date Javascript Date Object
-		 * @return {object}      rounded javascript date object
-		 */
-		function roundMinutes(date) {
-			var rounder = Math.floor(date.getMinutes()/options.stepMinute);
-
-			if (date.getMinutes()%options.stepMinute > (options.stepMinute/2)) {
-				rounder = rounder + 1;
-			}
-
-			var min = rounder*options.stepMinute;
-
-			date.setMinutes(min);
-
-			return date;
-		}
 
 
 		/**
@@ -2201,7 +2179,8 @@ isRTL:false
 		}
 
 		/**
-		 * Initiallizes the base date for the picker
+		 * Initiallizes the base date for the picker.
+		 * This gets the date that should be displayed to the user.
 		 * 
 		 */
 		var initDateTime = function () {
@@ -2271,11 +2250,9 @@ isRTL:false
 		};
 
 		/**
-		 * Event handler for language ajax call, loading a particular language
-		 * 
-		 * @param  {object} ll 2 variables are loaded in to the scrip: lang and timeLang
+		 * Sets up the datetimepicker.
 		 */
-		var langLoaded = function(ll) {
+		var init = function() {
 
 			// set the initial date for the picker
 			initDateTime();
@@ -2286,6 +2263,8 @@ isRTL:false
 			// set the datepicker date if we've got a pre-set value
 			if (typeof options.val !== 'undefined' || typeof options.getval !== 'undefined' || typeof options.duration !== 'undefined') {
 				localDTPicker.datetimepicker("setDate", localDate);
+				// At this point we can go and ask the picker what it has rounded the time to.
+				localDate = localDTPicker.datetimepicker("getDate");
 				// Handle duration, which relies on the datepicker being set
 				handleDuration();
 			}
@@ -2325,7 +2304,7 @@ isRTL:false
            }
          }
 
-         langLoaded(true);
+         init();
 	};
 
 	// A really lightweight plugin wrapper around the constructor, 


### PR DESCRIPTION
The date/time picker in Sakai 10 allows only 5 minute intervals, but when fields in the evaluations tool are setup they contain date/times that aren’t already rounded. There was some Sakai code to perform initial rounding but this used a different algorithm and would round the minute value across days so then trying to create a time at the end of a day it would jump into the next day. 

The plugin does sensible rounding so the change just gets the rounded value from the picker after we’ve set it up and resets all the hidden field to that value.

It also fixes a bug where if the initial set time wasn’t on a rounded boundary the displayed time didn’t match the value that was submitted in the form.
