### PR TITLE
WL-3625 Don’t add jQuery to a tool’s page.

### DIFF
--- a/library/src/webapp/editor/ckeditor.launch.js
+++ b/library/src/webapp/editor/ckeditor.launch.js
@@ -221,11 +221,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
 			 //ckconfig.contentsCss = basePath+'/atd-ckeditor/atd.css';
 
 			 ckconfig.extraPlugins+="audiorecorder,movieplayer,wordcount,fmath_formula";
-
     })();
-
-    // ensure jQuery exists for when the editor loads
-    CKEDITOR.scriptLoader.load('//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js');
 
 	  CKEDITOR.replace(targetId, ckconfig);
       //SAK-22505


### PR DESCRIPTION
Originally under WL-3501 jQuery was added to the page of a tool containing CKEditor, however this is proven to break the lessons tool so I’m reverting this change to get it working again.
