### PR TITLE
WL-3320 : Remove grey RHS border on selected tool

### DIFF
--- a/library/src/webapp/skin/neo-ox/portal.css
+++ b/library/src/webapp/skin/neo-ox/portal.css
@@ -793,8 +793,13 @@ ul#otherSiteList li a span, ul.otherSitesCategorList li a span {
     border-bottom: 1px solid #ccc;
     text-align: right;
     background: #f3f3f3;
+    border-right: 1px solid #ccc;
 }
 /* the current tool */
+#toolMenu li.selectedTool {
+    border-right: none;
+}
+
 #toolMenu li.selectedTool a {
     color: #155FB5 !important;
     background:none repeat scroll 0 0 #fff;
@@ -853,7 +858,7 @@ ul#otherSiteList li a span, ul.otherSitesCategorList li a span {
 
 #toolMenu {
     border: 1px solid #ccc;
-    border-width: 1px 1px 1px 0;
+    border-width: 1px 0px 1px 0;
     -moz-border-radius: 0 5px 5px 0;
     -webkit-border-radius: 0 5px 5px 0;
     border-radius: 0 5px 5px 0;
@@ -863,6 +868,7 @@ ul#otherSiteList li a span, ul.otherSitesCategorList li a span {
 /* adjusting rendering of first and last item in the tool menu */
 #toolMenu li:last-of-type {
     border-width: 0;
+    border-right:1px solid #ccc;
 }
 
 #toolMenu ul:last-of-type, #toolMenu li:last-of-type, #toolMenu li:last-of-type a {


### PR DESCRIPTION
Because the border is around the whole list of tools, this involves removing the RHS 1px border from this border and adding it individually to each tool and then removing it from the selected tool
