### PR TITLE
WL-3714 : Render IE11 'Minimise' text offscreen

### DIFF
--- a/library/src/webapp/skin/neo-ox/portal.css
+++ b/library/src/webapp/skin/neo-ox/portal.css
@@ -1669,7 +1669,7 @@ div#privacy_overlay {
     width: 1px !important; 
     overflow: hidden !important;
     top: 0px !important;
-    left: 0px; 
+    left: -999px;
     padding: 0px 0px 0px 0px !important;
 } 
 

--- a/library/src/webapp/skin/tool_base.css
+++ b/library/src/webapp/skin/tool_base.css
@@ -798,7 +798,7 @@ input.upload{
 	display: inline;
 	position: absolute;
 	top: -999px;
-	left: -999px;
+	left: -999px !important;
 	height: 0;
 }
 /*"inactive" gets applied to a container whose children you want to make look grayed out (not inactive per se) - applies to all textual elements and images

--- a/library/src/webapp/skin/tool_base.css
+++ b/library/src/webapp/skin/tool_base.css
@@ -798,7 +798,7 @@ input.upload{
 	display: inline;
 	position: absolute;
 	top: -999px;
-	left: -999px !important;
+	left: -999px;
 	height: 0;
 }
 /*"inactive" gets applied to a container whose children you want to make look grayed out (not inactive per se) - applies to all textual elements and images


### PR DESCRIPTION
The 'Minimise' em text (used for accessibility), which has position:fixed is, as a result,
given display:block in Firefox and Chrome and IE 8,9 but not in IE1, which has display:inline.

Changing it to display:block in IE11 does not seem to make a difference.

This change moves the text offscreen.
