### PR TITLE
WL-3502: Changes to how the Youtube widget works

### DIFF
--- a/library/src/webapp/editor/ckextraplugins/common/css/dialog.css
+++ b/library/src/webapp/editor/ckextraplugins/common/css/dialog.css
@@ -1,10 +1,10 @@
 /* search results paging styles */
-*[id$='SearchResults'] .pagination {
+.pagination {
 	overflow: hidden;
 	padding: 1px;
 }
 
-*[id$='SearchResults'] .pageNum  {
+.pageNum  {
 	float: left;
 	display: block;
 	border: 1px solid #d3d3d3;
@@ -15,13 +15,17 @@
 	text-decoration: none;
 }
 
-*[id$='SearchResults'] .currentPageNum {
+.currentPageNum {
 	background: none repeat scroll 0 0 #e9e9e9;
 }
 
-*[id$='SearchResults'] .pageSpan {
+.pageSpan {
 	font-weight: bold;
 	font-size: 11px;
 	color: #333;
 	cursor: pointer !important;
+}
+
+a:link {
+	text-decoration: none;
 }

--- a/library/src/webapp/editor/ckextraplugins/common/css/dialog.css
+++ b/library/src/webapp/editor/ckextraplugins/common/css/dialog.css
@@ -1,0 +1,27 @@
+/* search results paging styles */
+*[id$='SearchResults'] .pagination {
+	overflow: hidden;
+	padding: 1px;
+}
+
+*[id$='SearchResults'] .pageNum  {
+	float: left;
+	display: block;
+	border: 1px solid #d3d3d3;
+	margin: 2px;
+	padding: 6px 10px;
+	cursor: pointer !important;
+	background: none repeat scroll 0 0 #f8f8f8;
+	text-decoration: none;
+}
+
+*[id$='SearchResults'] .currentPageNum {
+	background: none repeat scroll 0 0 #e9e9e9;
+}
+
+*[id$='SearchResults'] .pageSpan {
+	font-weight: bold;
+	font-size: 11px;
+	color: #333;
+	cursor: pointer !important;
+}

--- a/library/src/webapp/editor/ckextraplugins/common/js/itemsearch.js
+++ b/library/src/webapp/editor/ckextraplugins/common/js/itemsearch.js
@@ -107,7 +107,7 @@ $.fn.itemSearch = function(options) {
 
     // build page numbers and containers
 
-    var currentPage = YouTubeSearchService.pt.currentPage;
+    var currentPage = $.fn.itemSearch.currentPage;
     if (currentPage >= 1 && currentPage  <=4){
       if (currentPage  > 1){
           appendBackButton(nav, currentPage );
@@ -136,7 +136,7 @@ $.fn.itemSearch = function(options) {
       var $this = $(this);
       var page = $this.data('page');
 
-      YouTubeSearchService.pt.currentPage = page;
+      $.fn.itemSearch.currentPage = page;
       var searchButtonLink = document.getElementById('youTubeSearchIframe').contentWindow.document.forms[0].children[1];
       searchButtonLink.click();
       return false;
@@ -148,7 +148,7 @@ $.fn.itemSearch = function(options) {
 
     // show the first page
     container.find('.page').hide();
-    container.find('.page[data-page="' + YouTubeSearchService.pt.currentPage + '"]').show();
+    container.find('.page[data-page="' + $.fn.itemSearch.currentPage + '"]').show();
 
     return $('<div/>').append(container).html();
   };

--- a/library/src/webapp/editor/ckextraplugins/common/js/itemsearch.js
+++ b/library/src/webapp/editor/ckextraplugins/common/js/itemsearch.js
@@ -80,16 +80,16 @@ $.fn.itemSearch = function(options) {
   };
 
   var appendBackButton = function(nav, currentPage, iFrameId){
-      nav.append($('<a/>').html('<span class="pageSpan">« Back</span>').attr({'class': 'pageNum ' + iFrameId, 'href': '#', 'data-page': currentPage-1}));
+      nav.append($('<a/>').html('<span class="pageSpan">« Back</span>').attr({'id' : iFrameId, 'class': 'pageNum', 'href': '#', 'data-page': currentPage-1}));
   };
 
   var appendPageButtons = function(i, currentPage, pagesContainer, nav, iFrameId){
       if (i == currentPage){
-          nav.append($('<a/>').html('<span class="pageSpan">' + i + '</span>').attr({'class': 'pageNum currentPageNum ' + iFrameId, 'href': '#', 'data-page': i}));
+          nav.append($('<a/>').html('<span class="pageSpan">' + i + '</span>').attr({'id' : iFrameId, 'class': 'pageNum currentPageNum', 'href': '#', 'data-page': i}));
           pagesContainer.append($('<div/>').attr({'class': 'page', 'data-page': i}));
       }
       else {
-          nav.append($('<a/>').html('<span class="pageSpan">' + i + '</span>').attr({'class': 'pageNum pageSpan ' + iFrameId, 'href': '#', 'data-page': i}));
+          nav.append($('<a/>').html('<span class="pageSpan">' + i + '</span>').attr({'id' : iFrameId, 'class': 'pageNum pageSpan', 'href': '#', 'data-page': i}));
           pagesContainer.append($('<div/>').attr({'class': 'page', 'data-page': i}));
       }
   };
@@ -118,7 +118,7 @@ $.fn.itemSearch = function(options) {
       }
     }
     else {
-        appendBackButton(nav, currentPage );
+        appendBackButton(nav, currentPage, iFrameId );
         for (i = currentPage-3; i <= currentPage +3; i++) {
             appendPageButtons(i, currentPage , pagesContainer, nav, iFrameId);
         }
@@ -133,14 +133,14 @@ $.fn.itemSearch = function(options) {
     }
 
     $(document).on('click', '.pageNum', function() {
-      // find closest results container
+      // click search button with current page
       var $this = $(this);
       var page = $this.data('page');
 
       $.fn.itemSearch.currentPage = page;
-      var searchResultsIFrameId = $.grep(this.classList, function(v) {return v.indexOf('Iframe')!=-1;});
-      var searchButtonLink = document.getElementById(searchResultsIFrameId).contentWindow.document.forms[0].children[1];
-      searchButtonLink.click();
+      var searchButton = $('#' + this.id).contents().find('a');
+      searchButton.click();
+      e.preventDefault();
       return false;
     });
 

--- a/library/src/webapp/editor/ckextraplugins/common/js/itemsearch.js
+++ b/library/src/webapp/editor/ckextraplugins/common/js/itemsearch.js
@@ -124,7 +124,7 @@ $.fn.itemSearch = function(options) {
         }
     }
 
-    nav.append($('<a/>').html('<span class="pageSpan">Next »</span>').attr({'class': 'pageNum ' + iFrameId, 'href': '#', 'data-page': currentPage +1}));
+    nav.append($('<a/>').html('<span class="pageSpan">Next »</span>').attr({'id': iFrameId, 'class': 'pageNum ' + iFrameId, 'href': '#', 'data-page': currentPage +1}));
     container.append(pagesContainer);
 
     // now move results into the correct containers
@@ -132,7 +132,7 @@ $.fn.itemSearch = function(options) {
       container.find('.page[data-page="' + currentPage + '"]').append(results[i]);
     }
 
-    $(document).on('click', '.pageNum', function() {
+    $(document).off('click', '.pageNum').on('click', '.pageNum', function() {
       // click search button with current page
       var $this = $(this);
       var page = $this.data('page');
@@ -140,7 +140,6 @@ $.fn.itemSearch = function(options) {
       $.fn.itemSearch.currentPage = page;
       var searchButton = $('#' + this.id).contents().find('a');
       searchButton.click();
-      e.preventDefault();
       return false;
     });
 

--- a/library/src/webapp/editor/ckextraplugins/common/js/itemsearch.js
+++ b/library/src/webapp/editor/ckextraplugins/common/js/itemsearch.js
@@ -78,7 +78,22 @@ $.fn.itemSearch = function(options) {
 
     return html;
   };
-  
+
+  var appendBackButton = function(nav, currentPage){
+      nav.append($('<a/>').html('<span class="pageSpan">« Back</span>').attr({'class': 'pageNum', 'href': '#', 'data-page': currentPage-1}));
+  };
+
+  var appendPageButtons = function(i, currentPage, pagesContainer, nav){
+      if (i == currentPage){
+          nav.append($('<a/>').html('<span class="pageSpan">' + i + '</span>').attr({'class': 'pageNum currentPageNum', 'href': '#', 'data-page': i}));
+          pagesContainer.append($('<div/>').attr({'class': 'page', 'data-page': i}));
+      }
+      else {
+          nav.append($('<a/>').html('<span class="pageSpan">' + i + '</span>').attr({'class': 'pageNum pageSpan', 'href': '#', 'data-page': i}));
+          pagesContainer.append($('<div/>').attr({'class': 'page', 'data-page': i}));
+      }
+  };
+
   var buildPaginatedResults = function(resultsHtml) {
     var results = $(resultsHtml);
         results = results.filter(function(result) {
@@ -91,28 +106,39 @@ $.fn.itemSearch = function(options) {
     var pagesContainer = $('<div/>').addClass('pages');
 
     // build page numbers and containers
-    for (i = 1; i <= pages; i++) {
-      nav.append($('<a/>').html(i).attr({'class': 'pageNum', 'href': '#', 'data-page': i}));
-      pagesContainer.append($('<div/>').attr({'class': 'page', 'data-page': i}));
-    };
 
+    var currentPage = YouTubeSearchService.pt.currentPage;
+    if (currentPage >= 1 && currentPage  <=4){
+      if (currentPage  > 1){
+          appendBackButton(nav, currentPage );
+      }
+      for (i = 1; i <= 7; i++) {
+          appendPageButtons(i, currentPage , pagesContainer, nav);
+      }
+    }
+    else {
+        appendBackButton(nav, currentPage );
+        for (i = currentPage-3; i <= currentPage +3; i++) {
+            appendPageButtons(i, currentPage , pagesContainer, nav);
+        }
+    }
+
+    nav.append($('<a/>').html('<span class="pageSpan">Next »</span>').attr({'class': 'pageNum', 'href': '#', 'data-page': currentPage +1}));
     container.append(pagesContainer);
 
     // now move results into the correct containers
     for (i = 0; i < results.length; i++) {
-      var page = Math.ceil((i+1) / settings.pagination);
-      container.find('.page[data-page="' + page + '"]').append(results[i]);
+      container.find('.page[data-page="' + currentPage + '"]').append(results[i]);
     }
 
     $(document).on('click', '.pageNum', function() {
       // find closest results container
       var $this = $(this);
-      var localContainer = $this.closest('.paginated-results');
       var page = $this.data('page');
 
-      localContainer.find('.page').hide();
-      localContainer.find('.page[data-page="' + page + '"]').show();
-
+      YouTubeSearchService.pt.currentPage = page;
+      var searchButtonLink = document.getElementById('youTubeSearchIframe').contentWindow.document.forms[0].children[1];
+      searchButtonLink.click();
       return false;
     });
 
@@ -122,7 +148,7 @@ $.fn.itemSearch = function(options) {
 
     // show the first page
     container.find('.page').hide();
-    container.find('.page[data-page="1"]').show();
+    container.find('.page[data-page="' + YouTubeSearchService.pt.currentPage + '"]').show();
 
     return $('<div/>').append(container).html();
   };

--- a/library/src/webapp/editor/ckextraplugins/common/js/itemsearch.js
+++ b/library/src/webapp/editor/ckextraplugins/common/js/itemsearch.js
@@ -79,17 +79,17 @@ $.fn.itemSearch = function(options) {
     return html;
   };
 
-  var appendBackButton = function(nav, currentPage){
-      nav.append($('<a/>').html('<span class="pageSpan">« Back</span>').attr({'class': 'pageNum', 'href': '#', 'data-page': currentPage-1}));
+  var appendBackButton = function(nav, currentPage, iFrameId){
+      nav.append($('<a/>').html('<span class="pageSpan">« Back</span>').attr({'class': 'pageNum ' + iFrameId, 'href': '#', 'data-page': currentPage-1}));
   };
 
-  var appendPageButtons = function(i, currentPage, pagesContainer, nav){
+  var appendPageButtons = function(i, currentPage, pagesContainer, nav, iFrameId){
       if (i == currentPage){
-          nav.append($('<a/>').html('<span class="pageSpan">' + i + '</span>').attr({'class': 'pageNum currentPageNum', 'href': '#', 'data-page': i}));
+          nav.append($('<a/>').html('<span class="pageSpan">' + i + '</span>').attr({'class': 'pageNum currentPageNum ' + iFrameId, 'href': '#', 'data-page': i}));
           pagesContainer.append($('<div/>').attr({'class': 'page', 'data-page': i}));
       }
       else {
-          nav.append($('<a/>').html('<span class="pageSpan">' + i + '</span>').attr({'class': 'pageNum pageSpan', 'href': '#', 'data-page': i}));
+          nav.append($('<a/>').html('<span class="pageSpan">' + i + '</span>').attr({'class': 'pageNum pageSpan ' + iFrameId, 'href': '#', 'data-page': i}));
           pagesContainer.append($('<div/>').attr({'class': 'page', 'data-page': i}));
       }
   };
@@ -108,22 +108,23 @@ $.fn.itemSearch = function(options) {
     // build page numbers and containers
 
     var currentPage = $.fn.itemSearch.currentPage;
+    var iFrameId = settings.resultsContainer[0].id.replace('Results', 'Iframe');
     if (currentPage >= 1 && currentPage  <=4){
       if (currentPage  > 1){
-          appendBackButton(nav, currentPage );
+          appendBackButton(nav, currentPage, iFrameId );
       }
       for (i = 1; i <= 7; i++) {
-          appendPageButtons(i, currentPage , pagesContainer, nav);
+          appendPageButtons(i, currentPage , pagesContainer, nav, iFrameId);
       }
     }
     else {
         appendBackButton(nav, currentPage );
         for (i = currentPage-3; i <= currentPage +3; i++) {
-            appendPageButtons(i, currentPage , pagesContainer, nav);
+            appendPageButtons(i, currentPage , pagesContainer, nav, iFrameId);
         }
     }
 
-    nav.append($('<a/>').html('<span class="pageSpan">Next »</span>').attr({'class': 'pageNum', 'href': '#', 'data-page': currentPage +1}));
+    nav.append($('<a/>').html('<span class="pageSpan">Next »</span>').attr({'class': 'pageNum ' + iFrameId, 'href': '#', 'data-page': currentPage +1}));
     container.append(pagesContainer);
 
     // now move results into the correct containers
@@ -137,7 +138,8 @@ $.fn.itemSearch = function(options) {
       var page = $this.data('page');
 
       $.fn.itemSearch.currentPage = page;
-      var searchButtonLink = document.getElementById('youTubeSearchIframe').contentWindow.document.forms[0].children[1];
+      var searchResultsIFrameId = $.grep(this.classList, function(v) {return v.indexOf('Iframe')!=-1;});
+      var searchButtonLink = document.getElementById(searchResultsIFrameId).contentWindow.document.forms[0].children[1];
       searchButtonLink.click();
       return false;
     });

--- a/library/src/webapp/editor/ckextraplugins/creative-commons-images/css/dialog.css
+++ b/library/src/webapp/editor/ckextraplugins/creative-commons-images/css/dialog.css
@@ -85,8 +85,7 @@
   white-space: normal !important;
 }
 
-#creativeCommonsImage
-SearchResults .pagination {
+#creativeCommonsImageSearchResults .pagination {
   overflow: hidden;
   padding: 1px;
 }

--- a/library/src/webapp/editor/ckextraplugins/creative-commons-images/css/dialog.css
+++ b/library/src/webapp/editor/ckextraplugins/creative-commons-images/css/dialog.css
@@ -14,12 +14,6 @@
   white-space: normal !important;
 }
 
-#creativeCommonsImageSearchIframe {
-  height: 50px !important;
-  width: 100% !important;
-  position: relative;
-}
-
 #creativeCommonsImageSearchForm form {
   margin: 0 auto;
   width: 400px;
@@ -91,7 +85,8 @@
   white-space: normal !important;
 }
 
-#creativeCommonsImageSearchResults .pagination {
+#creativeCommonsImage
+SearchResults .pagination {
   overflow: hidden;
   padding: 1px;
 }
@@ -99,16 +94,6 @@
   max-height: 350px;
   overflow-y: auto;
   margin: 3px 0 3px 0;
-}
-#creativeCommonsImageSearchResults .page {
-
-}
-#creativeCommonsImageSearchResults .pageNum {
-  float: left;
-  display: block;
-  border: 1px solid #CCC;
-  margin: 2px;
-  padding: 3px 5px;
 }
 
 #creativeCommonsImageSearchResults li {

--- a/library/src/webapp/editor/ckextraplugins/creative-commons-images/dialogs/creative-commons-images.js
+++ b/library/src/webapp/editor/ckextraplugins/creative-commons-images/dialogs/creative-commons-images.js
@@ -7,6 +7,7 @@ var path = h.path;
 var pathCommon = (path + '~').replace('creative-commons-images/~', 'common/');
 
 // load css and javascript files
+CKEDITOR.document.appendStyleSheet(CKEDITOR.getUrl(pathCommon+ 'css/dialog.css'));
 CKEDITOR.document.appendStyleSheet(CKEDITOR.getUrl(path + 'css/dialog.css'));
 
 CKEDITOR.scriptLoader.load(pathCommon + 'js/itemsearch.js');
@@ -57,9 +58,13 @@ CKEDITOR.dialog.add('creativeCommonsImagesDialog', function(editor) {
               var src = this.getValue();
               if (src) {
                   element.setAttribute('src', src);
+                  element.setAttribute('data-cke-saved-src', src);
+                  element.setAttribute('title', 'Credit: ' + src);
               }
-              else if (!this.insertMode)
+              else if (!this.insertMode){
                   element.removeAttribute('src');
+                  element.removeAttribute('title');
+              }
             }
           },
           {

--- a/library/src/webapp/editor/ckextraplugins/creative-commons-images/js/bind-creative-commons-image-search-to-dialog.js
+++ b/library/src/webapp/editor/ckextraplugins/creative-commons-images/js/bind-creative-commons-image-search-to-dialog.js
@@ -40,7 +40,7 @@ var BindCreativeCommonsImageSearchToDialog = function(path, dialog) {
   // now initialize iframe which will isolate the search field (so we can submit
   // the form without closing the dialog)
   var pushFormIntoIframe = function() {
-    var iframe = $('<iframe src="about:blank"></iframe>').attr('id', 'creativeCommonsImageSearchIframe');
+    var iframe = $('<iframe src="about:blank"></iframe>').attr('id', 'creativeCommonsImageSearchIframe').attr('style', 'height: 50px;width: 100%;');
     container.after(iframe);
 
     iframe.load(function() {

--- a/library/src/webapp/editor/ckextraplugins/creative-commons-images/js/bind-creative-commons-image-search-to-dialog.js
+++ b/library/src/webapp/editor/ckextraplugins/creative-commons-images/js/bind-creative-commons-image-search-to-dialog.js
@@ -40,7 +40,7 @@ var BindCreativeCommonsImageSearchToDialog = function(path, dialog) {
   // now initialize iframe which will isolate the search field (so we can submit
   // the form without closing the dialog)
   var pushFormIntoIframe = function() {
-    var iframe = $('<iframe src="about:blank"></iframe>').attr('id', 'creativeCommonsImageSearchIframe').attr('style', 'height: 50px;width: 100%;');
+    var iframe = $('<iframe src="about:blank"></iframe>').attr({ id:"creativeCommonsImageSearchIframe", style:"height: 50px; width: 100%;" });
     container.after(iframe);
 
     iframe.load(function() {

--- a/library/src/webapp/editor/ckextraplugins/creative-commons-images/js/service.js
+++ b/library/src/webapp/editor/ckextraplugins/creative-commons-images/js/service.js
@@ -14,7 +14,7 @@ var CreativeCommonsImageSearchService = function(params) {
     var query = $.extend({
       'sort': 'relevance',
       'license': 1,
-      'per_page': 20,
+      'per_page': 25
     }, settings);
 
     // check if we are searching via text or tags
@@ -44,16 +44,26 @@ var CreativeCommonsImageSearchService = function(params) {
           square: getImgLink(result, '_q'),
       }
     });
-  }
+  };
+
+  var resetTokensIfNewSearchTerm = function(currentSearchTerm, searchTerm){
+      if (currentSearchTerm != searchTerm){
+          $.fn.itemSearch.currentPage = 1;
+      }
+      $.fn.itemSearch.currentSearchTerm = searchTerm;
+  };
 
   // takes search term (string) and returns array of objects representing the
   // search results from YouTube
   this.performQuery = function(searchTerm) {
     var results = [];
+    resetTokensIfNewSearchTerm($.fn.itemSearch.currentSearchTerm, searchTerm);
+    var currentPage = $.fn.itemSearch.currentPage;
     var params = prepareQueryParams({
       text: searchTerm,
       tags: searchTerm,
       format: 'json',
+      page : currentPage,
       nojsoncallback: 1
     });
 

--- a/library/src/webapp/editor/ckextraplugins/solo-citation/css/dialog.css
+++ b/library/src/webapp/editor/ckextraplugins/solo-citation/css/dialog.css
@@ -8,10 +8,6 @@
   margin: 5px 5px 15px 0;
   white-space: normal !important;
 }
-#soloSearchIframe {
-  width: 100%;
-  height: 220px;
-}
 #soloSearchForm .searchquery {
   line-height: 30px;
 }
@@ -40,6 +36,7 @@
 /* search results */
 #soloSearchResults * {
   white-space: normal !important;
+	cursor: pointer;
 }
 
 #soloSearchResults .pagination {
@@ -60,7 +57,7 @@
   display: block;
   border: 1px solid #CCC;
   margin: 2px;
-  padding: 3px 5px;
+  padding: 6px 10px;
 }
 
 #soloSearchResults .result {

--- a/library/src/webapp/editor/ckextraplugins/solo-citation/dialogs/solo-citation.js
+++ b/library/src/webapp/editor/ckextraplugins/solo-citation/dialogs/solo-citation.js
@@ -8,6 +8,7 @@ var pathCommon = (path + '~').replace('solo-citation/~', 'common/');
 var pathCommonWl = (path + '~').replace('solo-citation/~', 'common-wl/');
 
 // load css and javascript files
+CKEDITOR.document.appendStyleSheet(CKEDITOR.getUrl(pathCommon + 'css/dialog.css'));
 CKEDITOR.document.appendStyleSheet(CKEDITOR.getUrl(path + 'css/dialog.css'));
 
 CKEDITOR.scriptLoader.load(pathCommon + 'js/itemsearch.js');
@@ -58,6 +59,7 @@ CKEDITOR.dialog.add('soloCitationDialog', function(editor) {
 
                 if (id) {
                   soloSearchResultId.trigger('submitItemSearchForm');
+                  soloSearchResultId.val(null);
                 }
               });
             },
@@ -87,6 +89,10 @@ CKEDITOR.dialog.add('soloCitationDialog', function(editor) {
       } else {
         this.insertMode = true;
       }
+      $('#soloCitationDialog .cke_dialog').css('top', '20px');
+
+      // http://ckeditor.com/forums/CKEditor-3.x/IFrame-Dialog-Disabling-ok-and-false-buttons-doesnt-work
+      document.getElementById(this.getButton('ok').domId).style.display='none';
     },
 
     onOk: function() {

--- a/library/src/webapp/editor/ckextraplugins/solo-citation/js/bind-solo-search-to-dialog.js
+++ b/library/src/webapp/editor/ckextraplugins/solo-citation/js/bind-solo-search-to-dialog.js
@@ -38,7 +38,7 @@ var BindSoloSearchToDialog = function(path) {
   // now initialize iframe which will isolate the search field (so we can submit
   // the form without closing the dialog)
   var pushFormIntoIframe = function() {
-    var iframe = $('<iframe src="about:blank"></iframe>').attr('id', 'soloSearchIframe');
+    var iframe = $('<iframe src="about:blank"></iframe>').attr({ id: 'soloSearchIframe', style: 'width: 100%; height: 220px;' });
     container.after(iframe);
 
     iframe.load(function() {

--- a/library/src/webapp/editor/ckextraplugins/solo-citation/js/service.js
+++ b/library/src/webapp/editor/ckextraplugins/solo-citation/js/service.js
@@ -12,12 +12,12 @@ var SOLOSearchService = function(params) {
   // fills in default settings for search query parameters
   var prepareQueryParams = function(settings) {
     var query = $.extend({
-      count: '5',
+      count: '10'
     }, settings);
 
     query = $.extend(query, params);
 
-    query.count = query.count || 5;
+    query.count = query.count || 10;
     delete query.form; // form was added in ItemSearch 0.1.2 (not needed in ajax call)
 
     return query;
@@ -31,14 +31,23 @@ var SOLOSearchService = function(params) {
       description: result.description,
       meta: result
     });
-  }
+  };
+
+  var resetTokensIfNewSearchTerm = function(currentSearchTerm, searchTerm){
+      if (currentSearchTerm != searchTerm){
+          $.fn.itemSearch.currentPage = 1;
+      }
+      $.fn.itemSearch.currentSearchTerm = searchTerm;
+  };
 
   // takes search term (string) and returns array of objects representing the
   // search results from SOLO
   this.performQuery = function(searchTerm) {
     var results = [];
-    var params = prepareQueryParams({title: searchTerm});
-    var ajaxUrl = url;
+      resetTokensIfNewSearchTerm($.fn.itemSearch.currentSearchTerm, searchTerm);
+      var params = prepareQueryParams({title: searchTerm});
+      params.start = ($.fn.itemSearch.currentPage-1) * params.count;
+      var ajaxUrl = url;
 
     if (params.id) {
       ajaxUrl = 'https://api.m.ox.ac.uk/library/item:' + params.id + '/';

--- a/library/src/webapp/editor/ckextraplugins/vimeo/dialogs/vimeo.js
+++ b/library/src/webapp/editor/ckextraplugins/vimeo/dialogs/vimeo.js
@@ -7,6 +7,7 @@ var path = h.path;
 var pathCommon = (path + '~').replace('vimeo/~', 'common/');
 
 // load css and javascript files
+CKEDITOR.document.appendStyleSheet(CKEDITOR.getUrl(pathCommon + 'css/dialog.css'));
 CKEDITOR.document.appendStyleSheet(CKEDITOR.getUrl(path + 'css/dialog.css'));
 
 CKEDITOR.scriptLoader.load(pathCommon + 'js/itemsearch.js');
@@ -92,6 +93,8 @@ CKEDITOR.dialog.add('vimeoDialog', function(editor) {
       } else {
         this.insertMode = true;
       }
+        // http://ckeditor.com/forums/CKEditor-3.x/IFrame-Dialog-Disabling-ok-and-false-buttons-doesnt-work
+        document.getElementById(this.getButton('ok').domId).style.display='none';
     },
 
     onOk: function() {

--- a/library/src/webapp/editor/ckextraplugins/vimeo/js/bind-itemsearch-to-container.js
+++ b/library/src/webapp/editor/ckextraplugins/vimeo/js/bind-itemsearch-to-container.js
@@ -13,7 +13,7 @@ var BindVimeoSearchToContainer = function(container, searchResults, result) {
       service: VimeoSearchService,
       resultsContainer: searchResults,
       displayResult: result.display,
-      pagination: false,
+      pagination: 1
     });
 
     container.find('input').addClass('searchQuery cke_dialog_ui_input_text')

--- a/library/src/webapp/editor/ckextraplugins/vimeo/js/service.js
+++ b/library/src/webapp/editor/ckextraplugins/vimeo/js/service.js
@@ -35,17 +35,26 @@ var VimeoSearchService = function(options) {
         more: result
       }
     });
-  }
+  };
+
+  var resetTokensIfNewSearchTerm = function(currentSearchTerm, searchTerm){
+      if (currentSearchTerm != searchTerm){
+          $.fn.itemSearch.currentPage = 1;
+      }
+      $.fn.itemSearch.currentSearchTerm = searchTerm;
+  };
 
   // takes search term (string) and returns array of objects representing the
   // search results from Vimeo
   this.performQuery = function(searchTerm) {
 
-    var results = [];
+      resetTokensIfNewSearchTerm($.fn.itemSearch.currentSearchTerm, searchTerm);
+      var currentPage = $.fn.itemSearch.currentPage;
+      var results = [];
 
     $.ajax({
       url: url,
-      data: { 'tool_id': 'vimeo', query: searchTerm },
+      data: { 'tool_id': 'vimeo', query: searchTerm, page : currentPage },
       type: 'POST',
       dataType: 'json',
       async: false,

--- a/library/src/webapp/editor/ckextraplugins/youtube/css/dialog.css
+++ b/library/src/webapp/editor/ckextraplugins/youtube/css/dialog.css
@@ -126,29 +126,3 @@
   padding: 6px;
   word-wrap: break-word !important;
 }
-
-#youTubeSearchResults .pagination {
-	overflow: hidden;
-	padding: 1px;
-}
-#youTubeSearchResults .pageNum {
-	float: left;
-	display: block;
-	border: 1px solid #d3d3d3;
-	margin: 2px;
-	padding: 6px 10px;
-	cursor: pointer !important;
-	background: none repeat scroll 0 0 #f8f8f8;
-	text-decoration: none;
-}
-
-#youTubeSearchResults .currentPageNum {
-	background: none repeat scroll 0 0 #e9e9e9;
-}
-
-#youTubeSearchResults .pageSpan {
-	font-weight: bold;
-	font-size: 11px;
-	color: #333;
-	cursor: pointer !important;
-}

--- a/library/src/webapp/editor/ckextraplugins/youtube/css/dialog.css
+++ b/library/src/webapp/editor/ckextraplugins/youtube/css/dialog.css
@@ -126,3 +126,29 @@
   padding: 6px;
   word-wrap: break-word !important;
 }
+
+#youTubeSearchResults .pagination {
+	overflow: hidden;
+	padding: 1px;
+}
+#youTubeSearchResults .pageNum {
+	float: left;
+	display: block;
+	border: 1px solid #d3d3d3;
+	margin: 2px;
+	padding: 6px 10px;
+	cursor: pointer !important;
+	background: none repeat scroll 0 0 #f8f8f8;
+	text-decoration: none;
+}
+
+#youTubeSearchResults .currentPageNum {
+	background: none repeat scroll 0 0 #e9e9e9;
+}
+
+#youTubeSearchResults .pageSpan {
+	font-weight: bold;
+	font-size: 11px;
+	color: #333;
+	cursor: pointer !important;
+}

--- a/library/src/webapp/editor/ckextraplugins/youtube/dialogs/youtube.js
+++ b/library/src/webapp/editor/ckextraplugins/youtube/dialogs/youtube.js
@@ -92,6 +92,8 @@ CKEDITOR.dialog.add('youtubeDialog', function(editor) {
       } else {
         this.insertMode = true;
       }
+      // http://ckeditor.com/forums/CKEditor-3.x/IFrame-Dialog-Disabling-ok-and-false-buttons-doesnt-work
+      document.getElementById(this.getButton('ok').domId).style.display='none';
     },
 
     onOk: function() {

--- a/library/src/webapp/editor/ckextraplugins/youtube/dialogs/youtube.js
+++ b/library/src/webapp/editor/ckextraplugins/youtube/dialogs/youtube.js
@@ -7,6 +7,7 @@ var path = h.path;
 var pathCommon = (path + '~').replace('youtube/~', 'common/');
 
 // load css and javascript files
+CKEDITOR.document.appendStyleSheet(CKEDITOR.getUrl(pathCommon + 'css/dialog.css'));
 CKEDITOR.document.appendStyleSheet(CKEDITOR.getUrl(path + 'css/dialog.css'));
 
 CKEDITOR.scriptLoader.load(pathCommon + 'js/itemsearch.js');

--- a/library/src/webapp/editor/ckextraplugins/youtube/js/bind-itemsearch-to-container.js
+++ b/library/src/webapp/editor/ckextraplugins/youtube/js/bind-itemsearch-to-container.js
@@ -14,7 +14,7 @@ var BindYouTubeSearchToContainer = function(container, searchResults, result) {
       service: YouTubeSearchService,
       resultsContainer: searchResults,
       displayResult: result.display,
-      pagination: false,
+      pagination: 1
     });
 
     // add css classes

--- a/library/src/webapp/editor/ckextraplugins/youtube/js/service.js
+++ b/library/src/webapp/editor/ckextraplugins/youtube/js/service.js
@@ -53,11 +53,11 @@ var YouTubeSearchService = function(options) {
 
   var resetTokensIfNewSearchTerm = function(currentSearchTerm, searchTerm){
       if (currentSearchTerm != searchTerm){
-          YouTubeSearchService.pt.pageTokens = new Array();
-          YouTubeSearchService.pt.currentPage = 1;
-          YouTubeSearchService.pt.pageTokens[1] = '';
+          $.fn.itemSearch.pageTokens = new Array();
+          $.fn.itemSearch.currentPage = 1;
+          $.fn.itemSearch.pageTokens[1] = '';
       }
-      YouTubeSearchService.pt.currentSearchTerm = searchTerm;
+      $.fn.itemSearch.currentSearchTerm = searchTerm;
   };
 
   var setNextPageToken = function(url, searchTerm, pageTokens, i){
@@ -83,9 +83,9 @@ var YouTubeSearchService = function(options) {
       throw 'NoYouTubeApiKeySpecified';
     }
 
-    resetTokensIfNewSearchTerm(YouTubeSearchService.pt.currentSearchTerm, searchTerm);
-    var pageTokens = YouTubeSearchService.pt.pageTokens;
-    var currentPage = YouTubeSearchService.pt.currentPage;
+    resetTokensIfNewSearchTerm($.fn.itemSearch.currentSearchTerm, searchTerm);
+    var pageTokens = $.fn.itemSearch.pageTokens;
+    var currentPage = $.fn.itemSearch.currentPage;
     var results = [];
 
     $.ajax({

--- a/library/src/webapp/editor/ckextraplugins/youtube/js/service.js
+++ b/library/src/webapp/editor/ckextraplugins/youtube/js/service.js
@@ -29,8 +29,9 @@ var YouTubeSearchService = function(options) {
       key: key,
       part: 'snippet',
       order: 'relevance',
-      maxResults: '5',
-      type: 'video',
+      pageToken : settings.pageToken,
+      maxResults: '25',
+      type: 'video'
     }, settings)
   }
 
@@ -50,6 +51,31 @@ var YouTubeSearchService = function(options) {
     });
   }
 
+  var resetTokensIfNewSearchTerm = function(currentSearchTerm, searchTerm){
+      if (currentSearchTerm != searchTerm){
+          YouTubeSearchService.pt.pageTokens = new Array();
+          YouTubeSearchService.pt.currentPage = 1;
+          YouTubeSearchService.pt.pageTokens[1] = '';
+      }
+      YouTubeSearchService.pt.currentSearchTerm = searchTerm;
+  };
+
+  var setNextPageToken = function(url, searchTerm, pageTokens, i){
+      if (pageTokens[i+1]==null) {
+          $.ajax({
+              url: url,
+              data: prepareQueryParams({q: searchTerm, pageToken: pageTokens[i]}),
+              dataType: 'json',
+              async: false,
+              success: function (json) {
+                  if (json.items.length > 0) {
+                      pageTokens[i + 1] = json.nextPageToken;
+                  }
+              }
+          });
+      }
+  };
+
   // takes search term (string) and returns array of objects representing the
   // search results from YouTube
   this.performQuery = function(searchTerm) {
@@ -57,18 +83,36 @@ var YouTubeSearchService = function(options) {
       throw 'NoYouTubeApiKeySpecified';
     }
 
+    resetTokensIfNewSearchTerm(YouTubeSearchService.pt.currentSearchTerm, searchTerm);
+    var pageTokens = YouTubeSearchService.pt.pageTokens;
+    var currentPage = YouTubeSearchService.pt.currentPage;
     var results = [];
 
     $.ajax({
       url: url,
-      data: prepareQueryParams({q: searchTerm}),
+      data: prepareQueryParams({q: searchTerm, pageToken: pageTokens[currentPage]}),
       dataType: 'json',
       async: false,
       success: function(json) {
         if (json.items.length > 0) {
-          // go through each result, formatting them for VideoSearch
-          $.each(json.items, function(key, item) {
-            formatResult(item, results);
+            pageTokens[currentPage+1] = json.nextPageToken;
+
+            // if they've clicked on page 1, then get the tokens for the pages up to 7
+            if (currentPage == 1) {
+                for (var i = 2; i <= 6; i++) {
+                    setNextPageToken(url, searchTerm, pageTokens, i);
+                }
+            }
+            // if they've clicked on page 5 or above, get the tokens for the previous 3 pages and the next 3 pages
+            else if (currentPage >= 5){
+                for (var i = currentPage-3; i <= currentPage+2; i++) {
+                    setNextPageToken(url, searchTerm, pageTokens, i);
+                }
+            }
+
+            // go through each result, formatting them for VideoSearch
+            $.each(json.items, function(key, item) {
+                formatResult(item, results);
           });
         }
       }


### PR DESCRIPTION
The Jira goes on a bit so a summary of the basic changes to how the widget currently works are:
1.   Just have one page of results showing, not 5.
2.   Make the Back, Next and page links look and work like Youtube's
3.   Disable the OK Button

The way the paging works below is that when a search is made, the results for page 1 are retrieved and with them also the pageTokens for the other pages (2-7).   When a page link is clicked, a click on the search button is then triggered using  the relevant pageToken.  

The currentPage is always stored so that when the Next button is clicked, we get the results for the pageToken after the one for currentPage.     
