### PR TITLE
WL-3872: Reset search term if it's a new widget (i.e., new url)

### DIFF
--- a/library/src/webapp/editor/ckextraplugins/creative-commons-images/js/service.js
+++ b/library/src/webapp/editor/ckextraplugins/creative-commons-images/js/service.js
@@ -46,18 +46,19 @@ var CreativeCommonsImageSearchService = function(params) {
     });
   };
 
-  var resetTokensIfNewSearchTerm = function(currentSearchTerm, searchTerm){
-      if (currentSearchTerm != searchTerm){
+  var resetTokensIfNewSearchTermOrWidget = function(currentSearchTerm, searchTerm, thisUrl, lastUrl){
+      if (currentSearchTerm != searchTerm || thisUrl != lastUrl){
           $.fn.itemSearch.currentPage = 1;
       }
       $.fn.itemSearch.currentSearchTerm = searchTerm;
+      $.fn.itemSearch.lastUrl = url;
   };
 
   // takes search term (string) and returns array of objects representing the
   // search results from YouTube
   this.performQuery = function(searchTerm) {
     var results = [];
-    resetTokensIfNewSearchTerm($.fn.itemSearch.currentSearchTerm, searchTerm);
+    resetTokensIfNewSearchTermOrWidget($.fn.itemSearch.currentSearchTerm, searchTerm, url, $.fn.itemSearch.lastUrl);
     var currentPage = $.fn.itemSearch.currentPage;
     var params = prepareQueryParams({
       text: searchTerm,

--- a/library/src/webapp/editor/ckextraplugins/solo-citation/js/service.js
+++ b/library/src/webapp/editor/ckextraplugins/solo-citation/js/service.js
@@ -33,18 +33,19 @@ var SOLOSearchService = function(params) {
     });
   };
 
-  var resetTokensIfNewSearchTerm = function(currentSearchTerm, searchTerm){
-      if (currentSearchTerm != searchTerm){
+  var resetTokensIfNewSearchTermOrWidget = function(currentSearchTerm, searchTerm, thisUrl, lastUrl){
+      if (currentSearchTerm != searchTerm || thisUrl != lastUrl){
           $.fn.itemSearch.currentPage = 1;
       }
       $.fn.itemSearch.currentSearchTerm = searchTerm;
+      $.fn.itemSearch.lastUrl = url;
   };
 
   // takes search term (string) and returns array of objects representing the
   // search results from SOLO
   this.performQuery = function(searchTerm) {
     var results = [];
-      resetTokensIfNewSearchTerm($.fn.itemSearch.currentSearchTerm, searchTerm);
+      resetTokensIfNewSearchTermOrWidget($.fn.itemSearch.currentSearchTerm, searchTerm, url, $.fn.itemSearch.lastUrl);
       var params = prepareQueryParams({title: searchTerm});
       params.start = ($.fn.itemSearch.currentPage-1) * params.count;
       var ajaxUrl = url;

--- a/library/src/webapp/editor/ckextraplugins/vimeo/js/service.js
+++ b/library/src/webapp/editor/ckextraplugins/vimeo/js/service.js
@@ -37,18 +37,19 @@ var VimeoSearchService = function(options) {
     });
   };
 
-  var resetTokensIfNewSearchTerm = function(currentSearchTerm, searchTerm){
-      if (currentSearchTerm != searchTerm){
+  var resetTokensIfNewSearchTermOrWidget = function(currentSearchTerm, searchTerm, thisUrl, lastUrl){
+      if (currentSearchTerm != searchTerm || thisUrl != lastUrl){
           $.fn.itemSearch.currentPage = 1;
       }
       $.fn.itemSearch.currentSearchTerm = searchTerm;
+      $.fn.itemSearch.lastUrl = url;
   };
 
   // takes search term (string) and returns array of objects representing the
   // search results from Vimeo
   this.performQuery = function(searchTerm) {
 
-      resetTokensIfNewSearchTerm($.fn.itemSearch.currentSearchTerm, searchTerm);
+      resetTokensIfNewSearchTermOrWidget($.fn.itemSearch.currentSearchTerm, searchTerm, url, $.fn.itemSearch.lastUrl);
       var currentPage = $.fn.itemSearch.currentPage;
       var results = [];
 

--- a/library/src/webapp/editor/ckextraplugins/youtube/js/service.js
+++ b/library/src/webapp/editor/ckextraplugins/youtube/js/service.js
@@ -51,13 +51,14 @@ var YouTubeSearchService = function(options) {
     });
   }
 
-  var resetTokensIfNewSearchTerm = function(currentSearchTerm, searchTerm){
-      if (currentSearchTerm != searchTerm){
+  var resetTokensIfNewSearchTermOrWidget = function(currentSearchTerm, searchTerm, thisUrl, lastUrl){
+      if (currentSearchTerm != searchTerm || thisUrl != lastUrl){
           $.fn.itemSearch.pageTokens = new Array();
           $.fn.itemSearch.currentPage = 1;
           $.fn.itemSearch.pageTokens[1] = '';
       }
       $.fn.itemSearch.currentSearchTerm = searchTerm;
+      $.fn.itemSearch.lastUrl = url;
   };
 
   var setNextPageToken = function(url, searchTerm, pageTokens, i){
@@ -83,7 +84,7 @@ var YouTubeSearchService = function(options) {
       throw 'NoYouTubeApiKeySpecified';
     }
 
-    resetTokensIfNewSearchTerm($.fn.itemSearch.currentSearchTerm, searchTerm);
+    resetTokensIfNewSearchTermOrWidget($.fn.itemSearch.currentSearchTerm, searchTerm, url, $.fn.itemSearch.lastUrl);
     var pageTokens = $.fn.itemSearch.pageTokens;
     var currentPage = $.fn.itemSearch.currentPage;
     var results = [];


### PR DESCRIPTION
If it's a different widget someone is using, i.e., a different url queried, then we reset the search term.  
