### PR TITLE
WL-3507: Fixes for IE(11)

### DIFF
--- a/library/src/webapp/editor/ckextraplugins/common-wl/js/browser.js
+++ b/library/src/webapp/editor/ckextraplugins/common-wl/js/browser.js
@@ -1,0 +1,6 @@
+// generic browser functions
+
+var isIE = function() {  //  http://stackoverflow.com/questions/19999388/jquery-check-if-user-is-using-ie
+    var msie = window.navigator.userAgent.indexOf("MSIE ");
+    return msie > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./);
+};

--- a/library/src/webapp/editor/ckextraplugins/researcher-training-tool/dialogs/researcher-training-tool.js
+++ b/library/src/webapp/editor/ckextraplugins/researcher-training-tool/dialogs/researcher-training-tool.js
@@ -24,6 +24,7 @@ if (!$.fn.autocomplete) {
 
 CKEDITOR.scriptLoader.load(pathCommon + 'js/embed-assets-in-editor.js');
 CKEDITOR.scriptLoader.load(pathCommonWl + 'js/embed-jquery-assets-in-editor.js');
+CKEDITOR.scriptLoader.load(pathCommonWl + 'js/browser.js');
 CKEDITOR.scriptLoader.load(pathCommonWl + '/js/courses-js-widget/oxford-courses-widget.js');
 CKEDITOR.scriptLoader.load(pathCommonWl + 'js/oxpoints-autocomplete.js');
 CKEDITOR.scriptLoader.load(path + 'js/skills.js');
@@ -72,7 +73,7 @@ CKEDITOR.dialog.add('researcherTrainingToolDialog', function(editor) {
                   input.attr('data-name', input.val());
                 }
               });
-              if (!!navigator.userAgent.match(/Trident\/7\./)){  // http://stackoverflow.com/questions/18684099/jquery-fail-to-detect-ie-11
+              if (isIE()){
                   input.val("Search name of a department/college etc...");
                   input.one( "click", function() {$(this).val("");});
               }

--- a/library/src/webapp/editor/ckextraplugins/researcher-training-tool/dialogs/researcher-training-tool.js
+++ b/library/src/webapp/editor/ckextraplugins/researcher-training-tool/dialogs/researcher-training-tool.js
@@ -72,6 +72,10 @@ CKEDITOR.dialog.add('researcherTrainingToolDialog', function(editor) {
                   input.attr('data-name', input.val());
                 }
               });
+              if (!!navigator.userAgent.match(/Trident\/7\./)){  // http://stackoverflow.com/questions/18684099/jquery-fail-to-detect-ie-11
+                  input.val("Search name of a department/college etc...");
+                  input.one( "click", function() {$(this).val("");});
+              }
             },
             setup: function(element) {
               var uri = element.getAttribute('data-providedBy');
@@ -149,7 +153,7 @@ CKEDITOR.dialog.add('researcherTrainingToolDialog', function(editor) {
                 setup: function(element) {
                   var skills = element.getAttribute('data-skill');
                   if (skills)
-                    this.setValues(values.trim().split(' '));
+                    this.setValues(skills.trim().split(' '));
                 },
                 commit: function(element) {
                   var skills = this.getValues();

--- a/library/src/webapp/editor/ckextraplugins/researcher-training-tool/js/select-multiple-values.js
+++ b/library/src/webapp/editor/ckextraplugins/researcher-training-tool/js/select-multiple-values.js
@@ -8,7 +8,7 @@ CKEDITOR.ui.dialog.uiElement.prototype.getValues = function() {
   // get the options from the dialog's input element
   var select = this.getInputElement();
   var selectedOptions = select.$.selectedOptions;
-  if (!!navigator.userAgent.match(/Trident\/7\./)){    // http://stackoverflow.com/questions/18684099/jquery-fail-to-detect-ie-11
+  if (isIE()){
       selectedOptions = select.$.options.children;
   }
   var values = [];

--- a/library/src/webapp/editor/ckextraplugins/researcher-training-tool/js/select-multiple-values.js
+++ b/library/src/webapp/editor/ckextraplugins/researcher-training-tool/js/select-multiple-values.js
@@ -8,11 +8,16 @@ CKEDITOR.ui.dialog.uiElement.prototype.getValues = function() {
   // get the options from the dialog's input element
   var select = this.getInputElement();
   var selectedOptions = select.$.selectedOptions;
+  if (!!navigator.userAgent.match(/Trident\/7\./)){    // http://stackoverflow.com/questions/18684099/jquery-fail-to-detect-ie-11
+      selectedOptions = select.$.options.children;
+  }
   var values = [];
 
   // add values to array
   for (i = 0; i < selectedOptions.length; i++) {
-    values.push(selectedOptions[i].value);
+    if (selectedOptions[i].selected){
+        values.push(selectedOptions[i].value);
+    }
   }
 
   return values;


### PR DESCRIPTION
The placeholder attribute is not working in IE11 for the CKEditor RTT widget - it just has an empty input field and no javascript errors related to it. Tried a few different things (simulating a click or focus (which works if I do it)) and eventually I decided just to add a couple of lines checking for IE.

Also there is a difference between IE and other browsers with their rendering of multiselects. 
